### PR TITLE
Update html2pdf-v1.js

### DIFF
--- a/routes/html2pdf-v1.js
+++ b/routes/html2pdf-v1.js
@@ -154,7 +154,7 @@ function buildQueueItem(req, logger) {
         id,
         renderer,
         uri: request.uri,
-        headers: request.headers,
+        headers: req.headers,
         format: req.params.format
     };
     return new QueueItem(data);


### PR DESCRIPTION
Fixed headers forwarding lost. Due to the error in the code we could not send feaders and cookies from the user to the Chromium, as there is forwarding a wrong object (in the response obj). The right way is to use req object.